### PR TITLE
Fix small visual error

### DIFF
--- a/web_upload/themes/new_box/page_servers.tpl
+++ b/web_upload/themes/new_box/page_servers.tpl
@@ -91,7 +91,7 @@
 				<thead>
 					<tr>
 						<th class="text-center">Игра</th>
-						<th class="text-center hidden-xs">ОC</th>
+						<th class="text-center hidden-xs">OC</th>
 						<th class="text-center hidden-xs">VAC</th>
 						<th>Название сервера</th>
 						<th class="text-right">Игроки</th>


### PR DESCRIPTION
На главной, в списке серверов в колонке "ОС" использовалась одна русская буква. Лично мне это резало глаза :D