### PR TITLE
Фикс ваучеров (при пустой/неуказанной серверной группе)

### DIFF
--- a/web_upload/includes/sb-callback.php
+++ b/web_upload/includes/sb-callback.php
@@ -1324,9 +1324,9 @@ function AddAdmin_pay($mask, $srv_mask, $a_name, $a_steam, $a_email, $a_password
       $web_gruop_sql = "0";
     }
     $server_admin_group = $GLOBALS['db']->GetOne("SELECT `group_srv` FROM ".DB_PREFIX."_vay4er WHERE `value` = '".$a_code."'");
-    if($server_admin_group == ""){
-      $web_gruop_sql = "";
-    }
+    //if($server_admin_group == ""){
+    //  $web_gruop_sql = "";
+    //}
     $aid = $userbank->AddAdmin($a_name, $a_steam, $a_password, $a_email, $web_gruop_sql, $mask, $server_admin_group, $srv_mask, $immunity, $a_serverpass, $pay_days_sql, $skype, '', $vk);
     setcookie("aid", $aid, time()+LOGIN_COOKIE_LIFETIME);
     setcookie("password", $GLOBALS['db']->GetOne("SELECT `password` FROM `".DB_PREFIX."_admins` WHERE `aid` = '".$aid."'"), time()+LOGIN_COOKIE_LIFETIME);

--- a/web_upload/pages/page.commslist.php
+++ b/web_upload/pages/page.commslist.php
@@ -557,7 +557,28 @@ while (!$res->EOF)
 
 	//$data['mod_icon'] = '<img src="images/games/' .$modicon . '" alt="MOD" border="0" align="absmiddle" />&nbsp;' . $data['type_icon'];
 	$data['mod_icon'] = '<img src="images/games/' .$modicon . '" alt="MOD" border="0" align="absmiddle" />&nbsp;';
-	
+
+	// заюзаем иконку страны под отображение TYPE_MUTE or TYPE_GAG
+	switch((int)$data['type'])
+	{
+		case 1:
+			$data['type_icon'] = '<img src="images/type_v.png" alt="Микрофон" border="0" align="absmiddle" />';
+			$mute_count = $mute_count - 1;
+			break;
+		case 2:
+			$data['type_icon'] = '<img src="images/type_c.png" alt="Чат" border="0" align="absmiddle" />';
+			$gag_count = $gag_count - 1;
+			break;
+		case 3:
+			$data['type_icon'] = '<img src="images/type_silence.png" alt="Микрофон и чат" border=0 align="absmiddle" />';
+			$gag_count -= 1;
+			$mute_count -= 1;
+			break;
+		default:
+			$data['type_icon'] = '<img src="images/country/zz.gif" alt="Неизвестный тип блока" border="0" align="absmiddle" />';
+			break;
+	}
+
 	$data['type_icon_p'] = $data['type_icon'];
 	
     if($history_count > 1)


### PR DESCRIPTION
Пробую создать очередной пулл реквест.
У меня при регистрации через ваучер админка не добавлялась в `_admins`, покопался в коде и заметил (смотря на код), что если не указывать серверную группу (я их не использую в SB, у меня пока своя небольшая система выдаёт права в игре, но если добавят больше форвардов касательно админов (если это возможно) - я буду только рад.), то веб-группа тоже очищается. В итоге SB пытается пропихнуть пустую строку туда, где требуется `INT` и нет значения по умолчанию. 

Только я не знаю, почему https://github.com/SB-MaterialAdmin/Web/commit/2d95b368d214a238c631792b772d51441af8982d утащился и в этот реквест, хотя это вроде как другой бранч...
Ну, в случае чего можно будет закрыть реквест и сделать прямой (без моего участия) коммит.