### PR TITLE
Исправление невозможности замутить игрока через Веб-бан пока он на сервере

### DIFF
--- a/pages/admin.blockit.php
+++ b/pages/admin.blockit.php
@@ -115,7 +115,7 @@ function BlockPlayer($check, $sid, $num, $type, $length) {
     	        }
     	    }
 		} else
-			$gothim = (strpos($r->SendCommand("ma_wb_mute {$type} {$length} {$check}"), "ok") !== FALSE);
+			$gothim = (strpos($r->SendCommand("ma_wb_mute {$type} {$length} {$check} \"Веб-бан\""), "ok") !== FALSE);
 
 		if ($gothim) {
             $GLOBALS['db']->Execute("UPDATE `".DB_PREFIX."_comms` SET sid = '".$sid."' WHERE authid = '".$check."' AND RemovedBy IS NULL;");


### PR DESCRIPTION
Из-за бага игрок, которого замутили в веб-бане, всё еще мог общаться, пока не выйдет с сервера. Команда ma_wb_mute Требует 4 аргумента (тип, колво минут, стим айди, причина) и если меньше 4 аргументов, команда не работает. Веб-бан же отправляет 3 аргумента (тип, колво минут, стим айди), поэтому он никогда не мутил игрока. Я добавил причину "Веб-бан", теперь сервер находит нарушителя и мутит, Нарушитель возможно испугается срока в размере 19165 days 16 hours 4 minutes 17 sec. Но я думаю это норма